### PR TITLE
swap name with address to enable namespace subscription replication

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "orbit-db-feedstore": "~1.4.0",
     "orbit-db-keystore": "~0.1.0",
     "orbit-db-kvstore": "~1.4.0",
-    "orbit-db-store": "~2.5.0",
+    "orbit-db-store": "git+ssh://git@github.com/dashevo/orbit-db-store",
     "orbit-db-pubsub": "~0.5.3"
   },
   "devDependencies": {

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -110,7 +110,7 @@ class OrbitDB {
   }
 
   /* Private methods */
-  async _createStore (type, address, options) {
+  async _createStore (type, address, name, options) {
     // Get the type -> class mapping
     const Store = databaseTypes[type]
 
@@ -135,15 +135,15 @@ class OrbitDB {
     const store = new Store(this._ipfs, this.id, address, opts)
     store.events.on('write', this._onWrite.bind(this))
 
-    // ID of the store is the address as a string
-    const addr = address.toString()
-    this.stores[addr] = store
+    // ID of the store is the name of the db
+    //const addr = address.toString()
+    this.stores[name] = store;
 
     // Subscribe to pubsub to get updates from peers,
     // this is what hooks us into the message propagation layer
     // and the p2p network
     if(opts.replicate && this._pubsub)
-      this._pubsub.subscribe(addr, this._onMessage.bind(this), this._onPeerConnected.bind(this))
+      this._pubsub.subscribe(name, this._onMessage.bind(this), this._onPeerConnected.bind(this))
 
     return store
   }
@@ -331,7 +331,7 @@ class OrbitDB {
 
     // Open the the database
     options = Object.assign({}, options, { accessControllerAddress: manifest.accessController })
-    return this._createStore(manifest.type, dbAddress, options)
+    return this._createStore(manifest.type, dbAddress, dbAddress.path, options)
   }
 
   // Save the database locally


### PR DESCRIPTION
Using db name instead of its address as the subscription topic in the ipfs pubsub communication.

This allows us to subscribe quorum nodes to a quorumhash topic where any changes to the local orbit-db get replicated automatically amongst the quorum members. Without this change the address of the db has to first exchanged among the quorum members for replication to start. Which would lead to a non-leaderless quorum set-up.